### PR TITLE
Update ednize.cljs

### DIFF
--- a/src/fipp/ednize.cljs
+++ b/src/fipp/ednize.cljs
@@ -83,5 +83,5 @@
   )
 
 (defn record->tagged [x]
-  (tagged-literal (s/split (-> x type pr-str) #"/" 2)
+  (tagged-literal (apply symbol (s/split (-> x type pr-str) #"/" 2))
                   (into {} x)))


### PR DESCRIPTION
Looking at your code i see a bug in
```clojure
(defn record->tagged [x]
  (tagged-literal (s/split (-> x type pr-str) #"/" 2)
(into {} x)))
```

If you look at the `tagged-literal` function, it requires symbol as a first argument.
```clojure
(defn tagged-literal
  [tag form]
  {:pre [(symbol? tag)]}
  (TaggedLiteral. tag form))
```
In your code, ` (s/split (-> x type pr-str) #"/" 2)` will never resolve to a symbol, but to a vector of two strings. Hence the assertion error:
```clojure
cljs.user=> (clojure.string/split (-> (->MyRecord "a") type pr-str) #"/" 2)
["cljs.user" "MyRecord"]
cljs.user=> (symbol? (clojure.string/split (-> (->MyRecord "a") type pr-str) #"/" 2))
false
```

To fix this, you need to convert the vector to symbol:
```clojure
cljs.user=> (apply symbol (clojure.string/split (-> (->MyRecord "a") type pr-str) #"/" 2))
cljs.user/MyRecord
cljs.user=> (symbol? (apply symbol (clojure.string/split (-> (->MyRecord "a") type pr-str) #"/" 2)))
true
```

So imho the fn should look like this:
```clojure
(defn record->tagged [x]
  (tagged-literal  (apply symbol (s/split (-> x type pr-str) #"/" 2))
                   (into {} x)))
```

